### PR TITLE
Added support for non version plugins

### DIFF
--- a/src/main/kotlin/io/github/pemistahl/versioncatalog/linter/plugin/VersionCatalogFormatter.kt
+++ b/src/main/kotlin/io/github/pemistahl/versioncatalog/linter/plugin/VersionCatalogFormatter.kt
@@ -115,6 +115,8 @@ abstract class VersionCatalogFormatter : DefaultTask() {
                     formattedPlugin = "$formattedPlugin, version = \"$version\" }"
                 } else if (version is TomlTable) {
                     formattedPlugin = "$formattedPlugin, version.ref = \"${version.get("ref")}\" }"
+                } else if (version == null) {
+                    formattedPlugin = "$formattedPlugin }"
                 }
 
                 formattedPlugin

--- a/src/test/kotlin/io/github/pemistahl/versioncatalog/linter/plugin/IOUtilsTest.kt
+++ b/src/test/kotlin/io/github/pemistahl/versioncatalog/linter/plugin/IOUtilsTest.kt
@@ -137,6 +137,7 @@ class IOUtilsTest {
                     listOf(
                         38..38 to "ktlint = { id = \"org.jlleitschuh.gradle.ktlint\", version.ref = \"ktlint\" }",
                         39..39 to "shadowJar = { id = \"com.github.johnrengelman.shadow\", version = \"8.1.1\" }",
+                        40..40 to "versionCatalogLinter = { id = \"io.github.pemistahl.version-catalog-linter\" }",
                     ),
             )
 

--- a/src/test/kotlin/io/github/pemistahl/versioncatalog/linter/plugin/VersionCatalogFormatterTest.kt
+++ b/src/test/kotlin/io/github/pemistahl/versioncatalog/linter/plugin/VersionCatalogFormatterTest.kt
@@ -65,6 +65,23 @@ class VersionCatalogFormatterTest {
     }
 
     @Test
+    fun testNonVersionedPluginFormatting() {
+        val inputPlugins = listOf(
+            35..35 to "ktlint = { id = \"org.jlleitschuh.gradle.ktlint\" }",
+            36..36 to "shadowJar = { id = \"com.github.johnrengelman.shadow\", version = \"8.1.1\" }",
+        )
+        val expected = listOf(
+            "ktlint = { id = \"org.jlleitschuh.gradle.ktlint\" }",
+            "shadowJar = { id = \"com.github.johnrengelman.shadow\", version = \"8.1.1\" }",
+        )
+
+        assertEquals(
+            expected,
+            task.formatPlugins(inputPlugins),
+        )
+    }
+
+    @Test
     fun testJoinCatalogSections() {
         val outputCatalogURL = javaClass.getResource("/outputVersionCatalog.toml")
         val expectedOutputCatalog = File(outputCatalogURL.toURI()).readText()

--- a/src/test/kotlin/io/github/pemistahl/versioncatalog/linter/plugin/VersionCatalogFormatterTest.kt
+++ b/src/test/kotlin/io/github/pemistahl/versioncatalog/linter/plugin/VersionCatalogFormatterTest.kt
@@ -65,23 +65,6 @@ class VersionCatalogFormatterTest {
     }
 
     @Test
-    fun testNonVersionedPluginFormatting() {
-        val inputPlugins = listOf(
-            35..35 to "ktlint = { id = \"org.jlleitschuh.gradle.ktlint\" }",
-            36..36 to "shadowJar = { id = \"com.github.johnrengelman.shadow\", version = \"8.1.1\" }",
-        )
-        val expected = listOf(
-            "ktlint = { id = \"org.jlleitschuh.gradle.ktlint\" }",
-            "shadowJar = { id = \"com.github.johnrengelman.shadow\", version = \"8.1.1\" }",
-        )
-
-        assertEquals(
-            expected,
-            task.formatPlugins(inputPlugins),
-        )
-    }
-
-    @Test
     fun testJoinCatalogSections() {
         val outputCatalogURL = javaClass.getResource("/outputVersionCatalog.toml")
         val expectedOutputCatalog = File(outputCatalogURL.toURI()).readText()
@@ -200,10 +183,12 @@ class VersionCatalogFormatterTest {
             listOf(
                 35..35 to "   shadowJar =          { id = \"com.github.johnrengelman.shadow\", version = \"8.1.1\" }  ",
                 36..36 to "ktlint = { version.ref = \"ktlint\", id = \"org.jlleitschuh.gradle.ktlint\" }  #  This is a comment.",
+                37..37 to "versionCatalogLinter = { id = \"io.github.pemistahl.version-catalog-linter\" }",
             ),
             listOf(
                 "ktlint = { id = \"org.jlleitschuh.gradle.ktlint\", version.ref = \"ktlint\" }",
                 "shadowJar = { id = \"com.github.johnrengelman.shadow\", version = \"8.1.1\" }",
+                "versionCatalogLinter = { id = \"io.github.pemistahl.version-catalog-linter\" }",
             ),
         )
     }

--- a/src/test/resources/outputVersionCatalog.toml
+++ b/src/test/resources/outputVersionCatalog.toml
@@ -37,3 +37,4 @@ jgoodies = [
 [plugins]
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 shadowJar = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
+versionCatalogLinter = { id = "io.github.pemistahl.version-catalog-linter" }


### PR DESCRIPTION
Formatting of plugins without version attribute does not add the closing parenthesis.

For example:

The following
```
androidLibrary = { id = "com.android.library" }
androidApplication = { id = "com.android.application" }
```

Get's formatted to 

```
androidApplication = { id = "com.android.application"
androidLibrary = { id = "com.android.library"
```